### PR TITLE
arb-deploy dev mode

### DIFF
--- a/arb-deploy
+++ b/arb-deploy
@@ -27,8 +27,8 @@ services:
     arb-ethbridge:
         image: arb-ethbridge
         build:
-#           context: https://github.com/OffchainLabs/arb-ethbridge.git#alpha
-            context: ./compose/arb-ethbridge
+#           context: https://github.com/OffchainLabs/arb-ethbridge.git#v0.1.0
+            context: %s
             args:
                 MNEMONIC: '%s'
                 NUM_WALLETS: %d
@@ -50,21 +50,23 @@ services:
             - %s:/home/user/contract.ao
         image: arb-validator
         build:
-#           context: https://github.com/OffchainLabs/arb-validator.git#alpha
-            context: ./compose/arb-validator
+#           context: https://github.com/OffchainLabs/arb-validator.git#v0.1.0
+            context: %s
             args:
                 WAIT_FOR: 'arb-ethbridge:17545'
                 ETH_URL: 'ws://arb-ethbridge:7545'
+                DEBUG: %d
                 ID: 0
         ports:
             - '1235:1235'
             - '1236:1236'
 """)
 
-def compose_header(mnemonic, num_wallets, num_validators, gas_per_wallet, gas_limit, verbose,
-    state_abspath, contract_abspath):
-    return (COMPOSE_HEADER % (mnemonic, num_wallets, num_validators, gas_per_wallet,
-        gas_limit, verbose, state_abspath, contract_abspath))
+def compose_header(cethbridge, mnemonic, num_wallets, num_validators, gas_per_wallet,
+                   gas_limit, verbose, state_abspath, contract_abspath, cvalidator, d):
+    return (COMPOSE_HEADER % (cethbridge, mnemonic, num_wallets, num_validators,
+                              gas_per_wallet, gas_limit, verbose, state_abspath,
+                              contract_abspath, cvalidator, int(d)))
 
 # Parameters: validator id, absolute path to state folder,
 # absolute path to contract, validator id
@@ -96,12 +98,14 @@ def compose_validator(validator_id, state_abspath, contract_abspath):
 
 # Compile contracts to `contract.ao` and export to Docker and run validators
 def deploy(contract_name, n_validators, mnemonic, verbose, gas_per_wallet,
-    gas_limit):
-    # Check for compose folder and get dependencies
-    if not os.path.isdir('compose'):
-        run('mkdir compose')
-        run('git clone https://github.com/OffchainLabs/arb-ethbridge.git ./compose/arb-ethbridge')
-        run('git clone https://github.com/OffchainLabs/arb-validator.git ./compose/arb-validator')
+           gas_limit, dev, s):
+    f = 'compose'
+    if dev:
+        dev_mode(f)
+    # dev-mode context
+    context = 'https://github.com/OffchainLabs/%s.git#v0.1.0'
+    if dev:
+        context = './' + f + '/' + '%s'
 
     # Create VALIDATOR_STATE_DIRNAME s if they don't exist
     states_path = os.path.abspath(VALIDATOR_STATE_DIRNAME)
@@ -112,34 +116,74 @@ def deploy(contract_name, n_validators, mnemonic, verbose, gas_per_wallet,
     # Check for DOCKER_COMPOSE_FILENAME and halt if running
     compose = os.path.abspath('./' + DOCKER_COMPOSE_FILENAME)
     if os.path.isfile(compose):
-        run('sudo docker-compose -f %s down' % compose)
+        run('docker-compose -f %s down' % compose, sudo=s)
+
+    # Check for any running docker containers
+    if subprocess.check_output(('sudo ' if s else '') + 'docker ps -q',
+                               shell=True).decode("utf-8") != '':
+        run('docker ps', sudo=s)
+        y = raw_input('Would you like to kill and remove ALL docker containers? [y/N] ')
+        if str(y).lower().strip() == 'y':
+            run('docker kill $(docker ps -q)', shell=True, sudo=s)
+            run('docker rm $(docker ps -aq)', shell=True, sudo=s)
+
+    # number of wallets
+    n_wallets = n_validators + 100
 
     # Overwrite DOCKER_COMPOSE_FILENAME
     contract = os.path.abspath(contract_name)
     contents = (
         compose_header(
+            context % 'arb-ethbridge',
             mnemonic,
-            max(n_validators, 100),
+            n_wallets,
             n_validators,
             gas_per_wallet,
             gas_limit,
             verbose,
             states_path + str(0),
-            contract
+            contract,
+            context % 'arb-validator',
+            dev,
         ) + ''.join([compose_validator(i, states_path + str(i), contract) for i in range(1, n_validators)]))
     with open(compose, 'w') as f:
         f.write(contents)
 
     # Build and run
-    run('sudo docker-compose -f %s build' % compose)
-    run('sudo docker-compose -f %s up' % compose)
+    run('docker-compose -f %s build' % compose, sudo=s)
+    run('docker-compose -f %s up' % compose, sudo=s)
+
+# Check for compose folder `f` and get dependencies
+def dev_mode(f):
+    if not os.path.isdir(f):
+        GC = 'git clone https://github.com/OffchainLabs/%s.git ./' + f + '/%s'
+        run('mkdir ' + f)
+        run(GC % ('arb-ethbridge', 'arb-ethbridge'))
+        run(GC % ('arb-validator', 'arb-validator'))
+        run(GC % ('arb-avm', 'arb-validator/arb-avm'))
+        run('ln -sf arb-validator/arb-avm ' + f + '/arb-avm')
+        y = str(raw_input('Link all providers locally? [Y/n] ')).lower().strip()
+        if y == 'y' or y == '':
+            run(GC % ('arb-web3-provider', 'arb-web3-provider'))
+            run(GC % ('arb-ethers-provider', 'arb-ethers-provider'))
+            run(GC % ('arb-truffle-provider', 'arb-truffle-provider'))
+            symlink = 'rm -rf node_modules/%s && ln -sf ../' + f + '/%s node_modules/%s'
+            link = lambda x: symlink % (x, x, x)
+            run(link('arb-web3-provider'), shell=True)
+            run(link('arb-ethers-provider'), shell=True)
+            run(link('arb-truffle-provider'), shell=True)
 
 # Run commands in shell
-def run(command):
+def run(command, shell=False, sudo=False):
     BOLD='\033[1m'
     END='\033[0m'
+    if sudo:
+        command = 'sudo ' + command
     print(BOLD + '$ %s\n' % command + END)
-    subprocess.call(command.split())
+    if shell:
+        os.system(command)
+    else:
+        subprocess.call(command.split())
 
 ### ----------------------------------------------------------------------------
 ### Command line interface
@@ -155,6 +199,10 @@ def main():
     parser.add_argument('n_validators', type=int,
         help='The number of validators to deploy.')
     # Optional
+    parser.add_argument('-d', '--dev', action='store_true', dest='dev',
+        help='Downloads dependencies into `compose` folder if not created yet')
+    parser.add_argument('-s', '--sudo', action='store_true', dest='sudo',
+        help='Run docker-compose with sudo. May be helpful for some platforms')
     parser.add_argument('-l', '--gasLimit', type=int,
         dest='gas_limit', default=6721975,
         help='The block gas limit in wei [ganache-cli parameter]')
@@ -181,7 +229,7 @@ def main():
 
     # Deploy
     deploy(args.contract, args.n_validators, args.mnemonic, verboseFlag,
-        args.gas_per_wallet, args.gas_limit)
+           args.gas_per_wallet, args.gas_limit, args.dev, args.sudo)
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
This is the same `arb-deploy` file as: https://github.com/OffchainLabs/demo-dapp-pet-shop/pull/1

> - [x] Added --dev or -d flag to create a compose folder and locally link arb-ethbridge, arb-validator, arb-avm, and optionally all three providers.
> - [x] Pinned non-dev-mode deploys to tag v0.1.0 for arb-ethbridge and arb-validator
> - [x] Added --sudo or -s flag to run all docker and docker-compose commands with sudo